### PR TITLE
Expose preferred pixel ratio to handle lower end android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ ResponsiveImage accepts the same props as Image plus a new prop called `sources`
     2: require('image!icon@2x.png'),
     3: { uri: 'https://example.com/icon@3x.png' },
   }}
+  preferredPixelRatio={2} // (optional) force ResponsiveImage to load a specified pixel ratio
 />
 ```
 

--- a/ResponsiveImage.js
+++ b/ResponsiveImage.js
@@ -16,9 +16,14 @@ export default class ResponsiveImage extends React.Component {
       uri: PropTypes.string,
     }),
     sources: PropTypes.objectOf(Image.propTypes.source),
+    preferredPixelRatio: PropTypes.number,
   };
 
-  static getClosestHighQualitySource(sources) {
+  static defaultProps = {
+    preferredPixelRatio: PixelRatio.get(),
+  };
+
+  static getClosestHighQualitySource(sources, preferredPixelRatio) {
     let pixelRatios = Object.keys(sources);
     if (!pixelRatios.length) {
       return null;
@@ -28,7 +33,7 @@ export default class ResponsiveImage extends React.Component {
       parseFloat(ratioA) - parseFloat(ratioB)
     );
     for (let ii = 0; ii < pixelRatios.length; ii++) {
-      if (pixelRatios[ii] >= PixelRatio.get()) {
+      if (pixelRatios[ii] >= preferredPixelRatio) {
         return sources[pixelRatios[ii]];
       }
     }
@@ -42,8 +47,8 @@ export default class ResponsiveImage extends React.Component {
   }
 
   render() {
-    let { source, sources } = this.props;
-    let optimalSource = ResponsiveImage.getClosestHighQualitySource(sources);
+    let { source, sources, preferredPixelRatio } = this.props;
+    let optimalSource = ResponsiveImage.getClosestHighQualitySource(sources, preferredPixelRatio);
     if (optimalSource) {
       source = optimalSource;
     }


### PR DESCRIPTION
This PR allows lower end Android devices to lower their image quality, because in most cases blurry images are better than running out of memory

Example usage:

``` js
ResponsiveImage.preferredPixelRatio = Math.max(ResponsiveImage.preferredPixelRatio - 1, 1);
```

Not terribly sure about this solution, but feedbacks are welcome!
