### PR TITLE
add prop for passing in custom component to render image

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ ResponsiveImage accepts the same props as Image plus a new prop called `sources`
     3: { uri: 'https://example.com/icon@3x.png' },
   }}
   preferredPixelRatio={2} // (optional) force ResponsiveImage to load a specified pixel ratio
+  renderImageElement={(props) => <FitImage {...props} />} // (optional) specify a custom function for rendering the image
+                      // For example from FitImage from react-native-fit-image
+                      // Renders with React Native's Image component if this prop isn't set
 />
 ```
 

--- a/ResponsiveImage.js
+++ b/ResponsiveImage.js
@@ -17,7 +17,7 @@ export default class ResponsiveImage extends React.Component {
     }),
     sources: PropTypes.objectOf(Image.propTypes.source),
     preferredPixelRatio: PropTypes.number,
-    renderer: PropTypes.func
+    renderImageElement: PropTypes.func
   };
 
   static defaultProps = {

--- a/ResponsiveImage.js
+++ b/ResponsiveImage.js
@@ -17,6 +17,7 @@ export default class ResponsiveImage extends React.Component {
     }),
     sources: PropTypes.objectOf(Image.propTypes.source),
     preferredPixelRatio: PropTypes.number,
+    renderer: PropTypes.func
   };
 
   static defaultProps = {
@@ -47,13 +48,20 @@ export default class ResponsiveImage extends React.Component {
   }
 
   render() {
-    let { source, sources, preferredPixelRatio } = this.props;
+    let { source, sources, preferredPixelRatio, renderImageElement } = this.props;
     let optimalSource = ResponsiveImage.getClosestHighQualitySource(sources, preferredPixelRatio);
     if (optimalSource) {
       source = optimalSource;
     }
     if (!source) {
       throw new Error(`Couldn't find an appropriate image source`);
+    }
+    if (renderImageElement) {
+      return renderImageElement({
+        ...this.props,
+        ref: (component) => { this._image = component; },
+        source: source
+      });
     }
 
     return (


### PR DESCRIPTION
This change allows ResponsiveImage to be used with other image component libraries. My use case was for using FitImage for dynamically sizing images when dimensions can't be set. Rather than choosing between ResponsiveImage and FitImage, this allows both to be used.